### PR TITLE
Silica pixelratio API

### DIFF
--- a/harbour-sailbook.pro
+++ b/harbour-sailbook.pro
@@ -20,6 +20,7 @@ INSTALLS += i18n_files
 CONFIG += sailfishapp
 
 QT += core \
+    gui \
     dbus
 PKGCONFIG += nemonotifications-qt5
 

--- a/qml/pages/ExternalWebview.qml
+++ b/qml/pages/ExternalWebview.qml
@@ -30,6 +30,8 @@ Item {
         experimental.userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_4 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko)"
         experimental.userStyleSheets: [Qt.resolvedUrl("../resources/css/external.css")]
         experimental.userScripts: Qt.resolvedUrl("../resources/js/external.js")
+        experimental.customLayoutWidth: parent.width / devicePixelRatio
+        experimental.overview: true
         clip: true
         opacity: loading? 0.0: 1.0
         url: externalUrl
@@ -37,6 +39,10 @@ Item {
             Media.detectDownload(request)
             Media.detectYoutubeDLVideo(request)
         }
+
+        // Rounding floating numbers in JS: https://stackoverflow.com/questions/9453421/how-to-round-float-numbers-in-javascript
+        // Default 1.5x zoom
+        property real devicePixelRatio: Math.round(1.5*Theme.pixelRatio * 10) / 10.0
 
         Behavior on opacity { FadeAnimation {} }
     }

--- a/qml/pages/FBWebview.qml
+++ b/qml/pages/FBWebview.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import QtWebKit 3.0
-import Nemo.DBus 2.0
+import org.nemomobile.dbus 2.0
 import Harbour.Sailbook.SFOS 1.0
 import "./js/util.js" as Util
 import "./js/messages.js" as Messages
@@ -83,15 +83,8 @@ Item {
         experimental.preferences.javascriptEnabled: true
         experimental.preferences.navigatorQtObjectEnabled: true
         experimental.preferences.developerExtrasEnabled: true
-
-        property variant devicePixelRatio: {//1.5
-            if (Screen.width <= 540) return 1.5;
-            else if (Screen.width > 540 && Screen.width <= 768) return 2.0;
-            else if (Screen.width > 768) return 3.0;
-        }
         experimental.customLayoutWidth: parent.width / devicePixelRatio
         experimental.overview: true
-
         experimental.userAgent: "Mozilla/5.0 (PlayStation 4 4.71) AppleWebKit/601.2 (KHTML, like Gecko)"
         experimental.userStyleSheets: Qt.resolvedUrl(Util.getThemeFileName(settings.enableNightmode))
         experimental.userScripts: Qt.resolvedUrl("../resources/js/sailbook.js")
@@ -102,6 +95,10 @@ Item {
         opacity: loading? 0.0: 1.0
         url: "https://m.facebook.com/home.php?sk=" + Util.getFeedPriority(settings.priorityFeed)
         onLoadingChanged: loading? undefined: Messages.publishNotifications();
+
+        // Rounding floating numbers in JS: https://stackoverflow.com/questions/9453421/how-to-round-float-numbers-in-javascript
+        // Default 1.5x zoom, can be adjusted in Settings
+        property real devicePixelRatio: Math.round(1.5*Theme.pixelRatio * 10) / 10.0
 
         Behavior on opacity { FadeAnimation {} }
 

--- a/qml/pages/FBWebview.qml
+++ b/qml/pages/FBWebview.qml
@@ -97,7 +97,7 @@ Item {
         onLoadingChanged: loading? undefined: Messages.publishNotifications();
 
         // Rounding floating numbers in JS: https://stackoverflow.com/questions/9453421/how-to-round-float-numbers-in-javascript
-        // Default 1.5x zoom, can be adjusted in Settings
+        // Default 1.5x zoom
         property real devicePixelRatio: Math.round(1.5*Theme.pixelRatio * 10) / 10.0
 
         Behavior on opacity { FadeAnimation {} }

--- a/src/harbour-sailbook.cpp
+++ b/src/harbour-sailbook.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     sailbook.clearCache();
 
     // Enable logger
-    enableLogger(true);
+    enableLogger(false);
 
     // Expose C++ modules to QML
     qmlRegisterType<OS>("Harbour.Sailbook.SFOS", 1, 0, "SFOS");

--- a/src/harbour-sailbook.cpp
+++ b/src/harbour-sailbook.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     sailbook.clearCache();
 
     // Enable logger
-    enableLogger(false);
+    enableLogger(true);
 
     // Expose C++ modules to QML
     qmlRegisterType<OS>("Harbour.Sailbook.SFOS", 1, 0, "SFOS");

--- a/src/os.h
+++ b/src/os.h
@@ -4,6 +4,7 @@
 #include <QtGlobal>
 #include <sailfishapp/sailfishapp.h>
 #include <nemonotifications-qt5/notification.h>
+#include <QtGui/QGuiApplication>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
 #include <QtCore/QList>


### PR DESCRIPTION
Silica pixelratio API taken in use.
This replaces our custom function to determine the pixelratio of the device.
The Silica pixelratio API is more consistent and adapts better to ever device.

Fixed #31 