### PR TITLE
Allow the user to select what kind of notification he/she wants

### DIFF
--- a/qml/harbour-sailbook.qml
+++ b/qml/harbour-sailbook.qml
@@ -54,7 +54,9 @@ ApplicationWindow
         id: settings
         path: "/apps/harbour-sailbook/settings"
 
-        property bool enableNotifications: false
+        property bool notifyRequests: false
+        property bool notifyMessages: false
+        property bool notifyNotifications: false
         property bool showFeed: true
         property bool showFriends: true
         property bool showMessages: true

--- a/qml/js/messages.js
+++ b/qml/js/messages.js
@@ -56,7 +56,7 @@ function _requests() {
         requestsDataOld = 0;
         sfos.closeNotificationByCategory("sailbook-request");
     }
-    else if(requestsDataOld != requestsData && settings.showFriends && settings.enableNotifications) {
+    else if(requestsDataOld != requestsData && settings.showFriends && settings.notifyRequests) {
         var title = requestsData==1? qsTr("New friend request"): qsTr("New friend requests");
         var text = requestsData==1? qsTr("You have %1 new friend request").arg(requestsData): qsTr("You have %1 friend requests").arg(requestsData);
         sfos.createNotification(title, text, "social", "sailbook-request");
@@ -70,7 +70,7 @@ function _messages() {
         messagesDataOld = 0;
         sfos.closeNotificationByCategory("sailbook-message");
     }
-    else if(messagesDataOld != messagesData && settings.showMessages && settings.enableNotifications) {
+    else if(messagesDataOld != messagesData && settings.showMessages && settings.notifyMessages) {
         var title = messagesData==1? qsTr("New message"): qsTr("New messages");
         var text = messagesData==1? qsTr("You have %1 new message").arg(messagesData): qsTr("You have %1 messages").arg(messagesData);
         sfos.createNotification(title, text, "social", "sailbook-message");
@@ -84,7 +84,7 @@ function _notifications() {
         notificationsDataOld = 0;
         sfos.closeNotificationByCategory("sailbook-notification");
     }
-    else if(notificationsDataOld != notificationsData && settings.showNotifications && settings.enableNotifications) {
+    else if(notificationsDataOld != notificationsData && settings.showNotifications && settings.notifyNotifications) {
         var title = notificationsData==1? qsTr("New notification"): qsTr("New notifications");
         var text = notificationsData==1? qsTr("You have %1 new notification").arg(notificationsData): qsTr("You have %1 notifications").arg(notificationsData);
         sfos.createNotification(title, text, "social", "sailbook-notification");

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -5,7 +5,9 @@ import "../js/util.js" as Util
 Dialog {
 
     onAccepted: {
-        settings.enableNotifications = notifications.checked
+        settings.notifyRequests = notifyRequests.checked
+        settings.notifyMessages = notifyMessages.checked
+        settings.notifyNotifications = notifyNotifications.checked
         settings.priorityFeed = priorityFeed.currentIndex
         settings.showFeed = showFeed.checked
         settings.showFriends = showFriends.checked
@@ -147,13 +149,25 @@ Dialog {
 
             SectionHeader{ text: qsTr("Notifications") }
 
-            IconTextSwitch {
-                id: notifications
-                text: qsTr("Enable notifications")
-                icon.source: "qrc:///images/icon-notifications.png"
-                icon.scale: Theme.iconSizeMedium/icon.width // Scale icons according to the screen sizes
-                checked: settings.enableNotifications
-                description: qsTr("%1 will send you notifications when you have a new message, a new notification or a friend request.").arg("Sailbook")
+            TextSwitch {
+                id: notifyRequests
+                text: qsTr("Notify friend requests")
+                checked: settings.notifyRequests
+                description: qsTr("%1 will send you notifications when getting a friend request.").arg("Sailbook")
+            }
+
+            TextSwitch {
+                id: notifyMessages
+                text: qsTr("Notify incoming messages")
+                checked: settings.notifyMessages
+                description: qsTr("%1 will send you notifications when receiving a new message.").arg("Sailbook")
+            }
+
+            TextSwitch {
+                id: notifyNotifications
+                text: qsTr("Notify new notifications")
+                checked: settings.notifyNotifications
+                description: qsTr("%1 will send you notifications when you have a new Facebook notification.").arg("Sailbook")
             }
         }
     }

--- a/translations/harbour-sailbook-de.ts
+++ b/translations/harbour-sailbook-de.ts
@@ -158,10 +158,6 @@
         <translation>externer Webbrowser</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Benachrichtigungen aktivieren</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Erscheinungsbild</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Top-Meldungen</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 benachrichtigt dich automatisch, wenn du neue Nachrichten erhältst, bei Facebook-Benachrichtigungen oder bei Freundschaftsanfragen.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook-es.ts
+++ b/translations/harbour-sailbook-es.ts
@@ -158,10 +158,6 @@
         <translation>navegador externo</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Notificaciones</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Apariencia</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Historias superiores</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 notificará sobre un nuevo mensaje, una nueva notificación o una solicitud de amistad.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook-fi.ts
+++ b/translations/harbour-sailbook-fi.ts
@@ -158,10 +158,6 @@
         <translation>Ulkoinen selain</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Ota käyttöön ilmoitukset</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Ulkoasu</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Parhaat tarinat</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 lähettää ilmoituksia kun saat uuden viestin, uuden ilmoituksen tai kaveripyynnön.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook-fr.ts
+++ b/translations/harbour-sailbook-fr.ts
@@ -158,10 +158,6 @@
         <translation>navigateur externe</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Activer les notifications</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Apparance</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Meilleures histoires</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 vous enverra des notifications lorsque vous recevez un nouveau message, une notification, ou une nouvelle demande d&apos;ami.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook-it.ts
+++ b/translations/harbour-sailbook-it.ts
@@ -158,10 +158,6 @@
         <translation>browser esterno</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Attiva notifiche</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Aspetto</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Storie principali</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 ti segnalerà l&apos;arrivo di un nuovo messaggio, notifica o richiesta di amicizia.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook-nl.ts
+++ b/translations/harbour-sailbook-nl.ts
@@ -158,10 +158,6 @@
         <translation>externe browser</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Schakel notificaties in</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Uitzicht</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Topverhalen</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 zal je meldingen sturen wanneer je een nieuw bericht, een nieuwe aanmelding of een vriend verzoek krijgt.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook-pl.ts
+++ b/translations/harbour-sailbook-pl.ts
@@ -158,10 +158,6 @@
         <translation>zewnętrzna przeglądarka</translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation>Włącz powiadomienia</translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation>Wygląd</translation>
     </message>
@@ -258,8 +254,28 @@
         <translation>Kultowe historie</translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
-        <translation>%1 będzie wysyłał powiadomienia kiedy dostaniesz nową wiadomość, nowe powiadomienie lub zaproszenie do znajomych.</translation>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-sailbook.ts
+++ b/translations/harbour-sailbook.ts
@@ -158,10 +158,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable notifications</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -258,7 +254,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 will send you notifications when you have a new message, a new notification or a friend request.</source>
+        <source>Notify friend requests</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify incoming messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when getting a friend request.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when receiving a new message.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify new notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 will send you notifications when you have a new Facebook notification.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This commit splits the enableNotifications boolean into 3 different
ones (friend requests, messages, and notifications).

I have not found a clean way to set all the 3 notifications booleans in
the settings if enableNotifications was set, so I decided to opt for
setting them to False by default.

I have been carrying a version of this patch in my phone for more than
a month and got reminded of its presence after updating to the latest
version. Without this patch, I get constant harassment from Facebook
when I only care about friend requests and messages notifications.
